### PR TITLE
Fix menu not loading for single digit days bug

### DIFF
--- a/Dont Eat Alone/Models/Menu.swift
+++ b/Dont Eat Alone/Models/Menu.swift
@@ -89,8 +89,13 @@ class MenuController{
         for menu in menus{
             let index = menu.date.index(menu.date.endIndex, offsetBy: -2)
             let sub = menu.date[index...]
-            if(sub == date){
-                return menu.overviewData[mealPeriod]
+            if let subInt = Int(sub), let dateInt = Int(date) {
+                if(subInt == dateInt){
+                    return menu.overviewData[mealPeriod]
+                }
+            } else {
+                // TODO: This should never happen, but handle this error gracefully if it does.
+                print ("Menu.swift L92: Could not cast day to int, an error has occured.")
             }
         }
         return nil


### PR DESCRIPTION
Fixes #14 

* Compares ints instead of comparing strings
* Casts from String to Int safely - ensures no crashes.
* This implementation will simply fail to load menus and print a message to
console pointing us to the bug if the cast fails.