### PR TITLE
Fix the Detailed Item View Controller

### DIFF
--- a/Dont Eat Alone/Base.lproj/Main.storyboard
+++ b/Dont Eat Alone/Base.lproj/Main.storyboard
@@ -148,11 +148,11 @@
                                 <color key="backgroundColor" red="0.95688390731811523" green="0.95684528350830078" blue="0.95686173439025879" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </view>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pwm-cg-sxf">
-                                <rect key="frame" x="72.5" y="-26.5" width="230" height="360"/>
+                                <rect key="frame" x="72.5" y="23.5" width="230" height="360"/>
                                 <color key="backgroundColor" red="0.65110021829999998" green="0.65865963699999996" blue="0.66666835550000003" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="360" id="CmP-dX-RUL"/>
-                                    <constraint firstAttribute="width" constant="230" id="cRh-e4-WDj"/>
+                                    <constraint firstAttribute="width" constant="230" id="1mY-Ja-A8m"/>
+                                    <constraint firstAttribute="height" constant="360" id="A4D-rD-kNg"/>
                                 </constraints>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
@@ -162,10 +162,10 @@
                         </subviews>
                         <color key="backgroundColor" red="0.84337515780000005" green="0.1253104655" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="nJW-37-XZM" firstAttribute="top" secondItem="Pwm-cg-sxf" secondAttribute="bottom" constant="70" id="84O-T4-WJm"/>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="height" secondItem="aZ5-99-Wlm" secondAttribute="height" multiplier="1:4" id="Bgh-rl-oMq"/>
+                            <constraint firstItem="Pwm-cg-sxf" firstAttribute="top" secondItem="EtT-jG-4fG" secondAttribute="top" constant="23.5" id="GkR-kr-ek7"/>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="trailing" secondItem="EtT-jG-4fG" secondAttribute="trailing" id="UmS-dU-9G2"/>
-                            <constraint firstItem="Pwm-cg-sxf" firstAttribute="centerX" secondItem="aZ5-99-Wlm" secondAttribute="centerX" id="fSf-pN-GxN"/>
+                            <constraint firstItem="Pwm-cg-sxf" firstAttribute="centerX" secondItem="EtT-jG-4fG" secondAttribute="centerX" id="h1R-BW-bAX"/>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="bottom" secondItem="EtT-jG-4fG" secondAttribute="bottom" id="irN-h0-OQw"/>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="leading" secondItem="EtT-jG-4fG" secondAttribute="leading" id="oot-CB-eDp"/>
                         </constraints>

--- a/Dont Eat Alone/Base.lproj/Main.storyboard
+++ b/Dont Eat Alone/Base.lproj/Main.storyboard
@@ -1033,6 +1033,5 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="GXr-Q7-bUb"/>
-        <segue reference="u7Y-xg-7CH"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Dont Eat Alone/Base.lproj/Main.storyboard
+++ b/Dont Eat Alone/Base.lproj/Main.storyboard
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -12,16 +11,16 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--First-->
+        <!--MenuVC-->
         <scene sceneID="hNz-n2-bh7">
             <objects>
                 <viewController id="9pv-A4-QxB" customClass="MenuVC" customModule="Dont_Eat_Alone" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="tsR-hK-woN">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="H9C-p3-hMb">
-                                <rect key="frame" x="0.0" y="105" width="375" height="465"/>
+                                <rect key="frame" x="0.0" y="85" width="375" height="421"/>
                                 <color key="backgroundColor" red="0.95688390729999995" green="0.95684528349999998" blue="0.9568617344" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="20" id="rXL-ol-5Oo">
                                     <size key="itemSize" width="365" height="214"/>
@@ -89,7 +88,7 @@
                                 </cells>
                             </collectionView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DoT-Hh-LNo" userLabel="Background">
-                                <rect key="frame" x="0.0" y="20" width="375" height="82"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="82" id="sl1-BF-aI0"/>
                                 </constraints>
@@ -98,7 +97,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fRI-GQ-wjj" userLabel="Allergens View" customClass="AllergensBarScrollView" customModule="Dont_Eat_Alone" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="570" width="375" height="48"/>
+                                <rect key="frame" x="0.0" y="506" width="375" height="48"/>
                                 <color key="backgroundColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="mHn-h5-kFh"/>
@@ -122,7 +121,9 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="PQr-Ze-W5v"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="First" image="first" id="acW-dT-cKf"/>
+                    <navigationItem key="navigationItem" id="moO-8J-WrT">
+                        <barButtonItem key="backBarButtonItem" title=" " id="yiO-24-r0l"/>
+                    </navigationItem>
                     <connections>
                         <outlet property="allergensBar" destination="fRI-GQ-wjj" id="VHL-kb-3Yb"/>
                         <outlet property="backgroundTopBar" destination="DoT-Hh-LNo" id="mh4-dU-Vvb"/>
@@ -132,22 +133,22 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="749.60000000000002" y="-320.68965517241384"/>
+            <point key="canvasLocation" x="1688.8" y="-320.68965517241384"/>
         </scene>
         <!--Item Detail View Controller-->
         <scene sceneID="8no-JV-0B6">
             <objects>
                 <viewController id="G2B-ru-Cr9" customClass="ItemDetailViewController" customModule="Dont_Eat_Alone" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="aZ5-99-Wlm">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nJW-37-XZM">
-                                <rect key="frame" x="0.0" y="500.5" width="375" height="166.5"/>
+                                <rect key="frame" x="0.0" y="403.5" width="375" height="150.5"/>
                                 <color key="backgroundColor" red="0.95688390731811523" green="0.95684528350830078" blue="0.95686173439025879" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </view>
                             <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pwm-cg-sxf">
-                                <rect key="frame" x="72.5" y="70.5" width="230" height="360"/>
+                                <rect key="frame" x="72.5" y="-26.5" width="230" height="360"/>
                                 <color key="backgroundColor" red="0.65110021829999998" green="0.65865963699999996" blue="0.66666835550000003" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="360" id="CmP-dX-RUL"/>
@@ -158,16 +159,8 @@
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7dv-Jh-igu">
-                                <rect key="frame" x="22" y="20" width="34" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Back"/>
-                                <connections>
-                                    <segue destination="9pv-A4-QxB" kind="show" id="jlk-vs-uiO"/>
-                                </connections>
-                            </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" red="0.84337515780000005" green="0.1253104655" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="top" secondItem="Pwm-cg-sxf" secondAttribute="bottom" constant="70" id="84O-T4-WJm"/>
                             <constraint firstItem="nJW-37-XZM" firstAttribute="height" secondItem="aZ5-99-Wlm" secondAttribute="height" multiplier="1:4" id="Bgh-rl-oMq"/>
@@ -185,7 +178,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZmK-mX-m7T" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1694" y="-191"/>
+            <point key="canvasLocation" x="2632.8000000000002" y="-191.1544227886057"/>
         </scene>
         <!--Item-->
         <scene sceneID="v0O-Ga-TGB">
@@ -799,7 +792,7 @@
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </tabBar>
                     <connections>
-                        <segue destination="9pv-A4-QxB" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
+                        <segue destination="RAT-qB-Fj9" kind="relationship" relationship="viewControllers" id="u7Y-xg-7CH"/>
                         <segue destination="nzh-LT-kup" kind="relationship" relationship="viewControllers" id="Fee-rG-eXp"/>
                         <segue destination="vm0-qx-c8l" kind="relationship" relationship="viewControllers" id="mAc-Fx-T4V"/>
                         <segue destination="aUf-9F-jVN" kind="relationship" relationship="viewControllers" id="mau-ZH-fAI"/>
@@ -1068,6 +1061,31 @@
             </objects>
             <point key="canvasLocation" x="-1239" y="1046"/>
         </scene>
+        <!--First-->
+        <scene sceneID="ieK-Zc-Zn1">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="RAT-qB-Fj9" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="First" image="first" id="acW-dT-cKf"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="Q4t-fk-ftE">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="barTintColor" red="0.8172110915184021" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="20"/>
+                            <color key="textColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="9pv-A4-QxB" kind="relationship" relationship="rootViewController" id="JpJ-xp-RtK"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="D7A-yq-DAM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="749.60000000000002" y="-320.68965517241384"/>
+        </scene>
     </scenes>
     <resources>
         <image name="Button" width="68" height="54"/>
@@ -1077,6 +1095,5 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="1ep-kA-o89"/>
-        <segue reference="u7Y-xg-7CH"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -19,6 +19,7 @@ class ItemDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         webView.scrollView.isScrollEnabled = false
+        webView.isUserInteractionEnabled = false
         self.view.backgroundColor = UIColor.deaScarlet
         ingredientsBar.backgroundColor = UIColor.white
         // Do any additional setup after loading the view.

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -25,6 +25,12 @@ class ItemDetailViewController: UIViewController {
         // Do any additional setup after loading the view.
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
+        self.navigationItem.title = self.menuItem?.name
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         let recipeID = extractRecipeIDFromRecipeURL(recipeURL: (menuItem?.recipeLink!)!) // TODO: hopefully, handle empty RecipeID

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -67,6 +67,9 @@ class ItemDetailViewController: UIViewController {
                 allergyString += allergen.rawValue + ", "
             }
         }
+        if (allergyString.isEmpty) {
+            return "None.";
+        }
         let index = allergyString.index(allergyString.endIndex, offsetBy: -2)
         return String(allergyString[...index])
     }

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -51,7 +51,16 @@ class ItemDetailViewController: UIViewController {
         let allergyString = buildAllergenString(allergies: (menuItem?.allergies)!)
         attributedString.append(NSMutableAttributedString(string: allergyString, attributes: normalAttrs))
         textView.attributedText = attributedString
+        
         ingredientsBar.addSubview(textView)
+        
+        // Add constraints to textView
+        textView.snp.makeConstraints { (make) -> Void in
+            make.top.equalTo(ingredientsBar).offset(20)
+            make.left.equalTo(ingredientsBar).offset(20);
+            make.bottom.equalTo(ingredientsBar).offset(-20)
+            make.right.equalTo(ingredientsBar).offset(-20);
+        }
     }
     
 

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -39,11 +39,11 @@ class ItemDetailViewController: UIViewController {
         
         let boldAttrs: [NSAttributedStringKey: Any] = [.font: UIFont(name: "AvenirNext-Medium", size: 12)!]
         let normalAttrs: [NSAttributedStringKey: Any] = [.font: UIFont(name: "AvenirNext-Regular", size: 12)!]
-        var attributedString = NSMutableAttributedString(string: "Ingredients: ", attributes:boldAttrs)
+        let attributedString = NSMutableAttributedString(string: "Ingredients: ", attributes:boldAttrs)
         attributedString.append(NSAttributedString(string: (menuItem?.ingredients)!, attributes: normalAttrs))
         attributedString.append(NSMutableAttributedString(string: "\n\nAllergens: ", attributes:boldAttrs))
-        // TODO: Figure out a way to display allergens as a string and then display that instead of ingredients twice
-        attributedString.append(NSMutableAttributedString(string: (menuItem?.ingredients)!, attributes: normalAttrs))
+        let allergyString = buildAllergenString(allergies: (menuItem?.allergies)!)
+        attributedString.append(NSMutableAttributedString(string: allergyString, attributes: normalAttrs))
         textView.attributedText = attributedString
         ingredientsBar.addSubview(textView)
     }
@@ -58,6 +58,17 @@ class ItemDetailViewController: UIViewController {
         let constPrefixCount = "http://menu.dining.ucla.edu/Recipes/".count
         let index = recipeURL.index(recipeURL.startIndex, offsetBy: constPrefixCount)
         return String(recipeURL[index...]);
+    }
+    
+    func buildAllergenString(allergies: [Allergen]) -> String {
+        var allergyString: String = ""
+        for allergen in allergies {
+            if (allergen != Allergen.Vegan && allergen != Allergen.Vegetarian) {
+                allergyString += allergen.rawValue + ", "
+            }
+        }
+        let index = allergyString.index(allergyString.endIndex, offsetBy: -2)
+        return String(allergyString[...index])
     }
 
 

--- a/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
+++ b/Dont Eat Alone/View Controllers/ItemDetailViewController.swift
@@ -86,7 +86,7 @@ class ItemDetailViewController: UIViewController {
             return "None.";
         }
         let index = allergyString.index(allergyString.endIndex, offsetBy: -2)
-        return String(allergyString[...index])
+        return String(allergyString[..<index])
     }
 
 

--- a/Dont Eat Alone/View Controllers/MenuVC.swift
+++ b/Dont Eat Alone/View Controllers/MenuVC.swift
@@ -69,6 +69,11 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
         computedHeight = Array(repeating: defaultHeight, count: self.diningHalls.count)
         // Do any additional setup after loading the view, typically from a nib.
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+    }
     
     let defaultHeight: CGFloat = 215;
     var computedHeight: [CGFloat] = [];

--- a/Dont Eat Alone/Views/Menu/MenuCardView.swift
+++ b/Dont Eat Alone/Views/Menu/MenuCardView.swift
@@ -61,6 +61,7 @@ class MenuCardView: UIView, UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         self.parentVC?.showItemDetailViewControllerFor(menuItem: data[indexPath.row])
+        tableView.deselectRow(at: indexPath, animated: true)
     }
     
     func numberOfSections(in tableView: UITableView) -> Int {


### PR DESCRIPTION
Fixes #23, Fixes #25, Fixes #18 

* Actually display allergens instead of ingredients twice.
* Add constraints to ingredients and allergens textView so it displays correctly on all phones.
* embed in navigation controller so that when back button is pressed it goes back to the same place the user came from.
* fixed bug where user interactions were allowed on the WebView
* fixed bug where if there were no allergens, then app would crash.
* Also fixes hiding of bottom bar on loading of Detailed VC.